### PR TITLE
Apply proper error handling when executing Lua via shell escape

### DIFF
--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -330,7 +330,7 @@
           }
         \iow_now:NV
           \g_tmpa_iow
-          \l_tmpa_tl
+          \l_tmpb_tl
         \iow_close:N
           \g_tmpa_iow
         \msg_info:nnV


### PR DESCRIPTION
Due to a typo, kpathsea is not loaded and errors are not handles when executing Lua via shell escape since version 2.0.0 (commit https://github.com/Witiko/lt3luabridge/commit/8a22a5bd30eeaf2de3cfef32a48abf1ae50ead09). This pull request fixes that.