### PR TITLE
Don't use LuaMetaTeX for ConTeXt MkIV example document

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: true
       matrix:
         command:
-          - context                                              --nonstopmode  example.context
+          - context                        --luatex              --nonstopmode  example.context
           - pdflatex --shell-escape                  --interaction=nonstopmode  example.latex
           - xelatex  --shell-escape --8bit           --interaction=nonstopmode  example.latex
           - lualatex                                 --interaction=nonstopmode  example.latex


### PR DESCRIPTION
Since TeX Live 2024, expl3 seems to no longer work in LuaMetaTeX. This PR switches to compiling the example ConTeXt MkIV document in LuaTeX instead of LuaMetaTeX.