### PR TITLE
Automatically determine the value of `\c_luabridge_default_output_dirname_str` based on `-output-directory` and test on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,16 +32,24 @@ jobs:
           - xetex    --shell-escape --8bit           --interaction=nonstopmode  example.plaintex
           - luatex                                   --interaction=nonstopmode  example.plaintex
     runs-on: ubuntu-latest
-    container:
-      image: texlive/texlive:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           set -e
-          apt-get -qy update
-          apt-get -qy install --no-install-recommends poppler-utils ruby
+          sudo apt-get -qy update
+          sudo apt-get -qy install --no-install-recommends libfontconfig1 poppler-utils ruby
+      - name: Install TeX Live
+        uses: teatimeguest/setup-texlive-action@v3
+        with:
+          packages: |
+            context
+            latex
+            luatex
+            scheme-minimal
+            standalone
+            xetex
       - name: Install lt3luabridge
         run: xetex lt3luabridge.ins
       - name: Compile example document
@@ -54,21 +62,33 @@ jobs:
           cat example.txt
           grep -q '1+2=3' example.txt
   prerelease:
-    name: Prerelease the package
+    name: Create artifacts and optionally prerelease the package
     needs:
       - markdownlint
       - test
     runs-on: ubuntu-latest
-    container:
-      image: texlive/texlive:latest
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           set -e
-          apt-get -qy update
-          apt-get -qy install --no-install-recommends zip
+          sudo apt-get -qy update
+          sudo apt-get -qy install --no-install-recommends libfontconfig1 zip
+      - name: Install TeX Live
+        uses: teatimeguest/setup-texlive-action@v3
+        with:
+          packages: |
+            alphalph
+            biber
+            biblatex
+            csquotes
+            enumitem
+            hologo
+            hypdoc
+            latex
+            latexmk
+            scheme-basic
       - name: Typeset documentation
         run: latexmk lt3luabridge.dtx
       - name: Produce lt3luabridge.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,6 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v3
         with:
           packages: |
-            collection-latex
             collection-luatex
             context
             latex
@@ -85,7 +84,6 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v3
         with:
           packages: |
-            collection-latex
             collection-luatex
             context
             latex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v3
         with:
           packages: |
+            collection-latex
             context
             latex
             luatex
@@ -82,6 +83,7 @@ jobs:
         uses: teatimeguest/setup-texlive-action@v3
         with:
           packages: |
+            collection-latex
             context
             latex
             luatex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,19 @@ jobs:
       fail-fast: true
       matrix:
         command:
-          - context                        --luatex              --nonstopmode  example.context
-          - pdflatex --shell-escape                  --interaction=nonstopmode  example.latex
-          - xelatex  --shell-escape --8bit           --interaction=nonstopmode  example.latex
-          - lualatex                                 --interaction=nonstopmode  example.latex
-          - pdftex   --shell-escape                  --interaction=nonstopmode  example.plaintex
-          - xetex    --shell-escape --8bit           --interaction=nonstopmode  example.plaintex
-          - luatex                                   --interaction=nonstopmode  example.plaintex
+          - context --luatex --nonstopmode
+          - pdflatex --shell-escape --interaction=nonstopmode
+          - xelatex --shell-escape --8bit --interaction=nonstopmode
+          - lualatex --interaction=nonstopmode
+          - pdftex --shell-escape --interaction=nonstopmode
+          - xetex --shell-escape --8bit --interaction=nonstopmode
+          - luatex --interaction=nonstopmode
+        extra_options:
+          - ''
+          - -output-directory .
+        exclude:
+          - command: context --luatex --nonstopmode
+            extra_options: -output-directory .
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -55,7 +61,7 @@ jobs:
       - name: Install lt3luabridge
         run: xetex lt3luabridge.ins
       - name: Compile example document
-        run: ${{ matrix.command }}
+        run: ${{ matrix.command }} ${{ matrix.extra_options }} example.tex
       - name: Extract text of the example document
         run: pdftotext example.pdf
       - name: Check the text of the example document
@@ -69,13 +75,19 @@ jobs:
       fail-fast: true
       matrix:
         command:
-          - context                        --luatex              --nonstopmode  example.context
-          - pdflatex --shell-escape                  --interaction=nonstopmode  example.latex
-          - xelatex  --shell-escape --8bit           --interaction=nonstopmode  example.latex
-          - lualatex                                 --interaction=nonstopmode  example.latex
-          - pdftex   --shell-escape                  --interaction=nonstopmode  example.plaintex
-          - xetex    --shell-escape --8bit           --interaction=nonstopmode  example.plaintex
-          - luatex                                   --interaction=nonstopmode  example.plaintex
+          - context --luatex --nonstopmode
+          - pdflatex --shell-escape --interaction=nonstopmode
+          - xelatex --shell-escape --8bit --interaction=nonstopmode
+          - lualatex --interaction=nonstopmode
+          - pdftex --shell-escape --interaction=nonstopmode
+          - xetex --shell-escape --8bit --interaction=nonstopmode
+          - luatex --interaction=nonstopmode
+        extra_options:
+          - ''
+          - -output-directory .
+        exclude:
+          - command: context --luatex --nonstopmode
+            extra_options: -output-directory .
     runs-on: windows-latest
     steps:
       - name: Checkout repository
@@ -95,7 +107,7 @@ jobs:
       - name: Install lt3luabridge
         run: xetex lt3luabridge.ins
       - name: Compile example document
-        run: ${{ matrix.command }}
+        run: ${{ matrix.command }} ${{ matrix.extra_options }} example.tex
   prerelease:
     name: Create artifacts and optionally prerelease the package
     needs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,7 @@ jobs:
             context
             latex
             luatex
+            pdftex
             scheme-minimal
             standalone
             xetex
@@ -87,6 +88,7 @@ jobs:
             context
             latex
             luatex
+            pdftex
             scheme-minimal
             standalone
             xetex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,8 +18,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run MarkdownLint
         uses: nosborn/github-action-markdown-cli@v2.0.0
-  test:
-    name: Compile example document
+  test-linux:
+    name: Compile example document with Linux
     strategy:
       fail-fast: true
       matrix:
@@ -61,11 +61,43 @@ jobs:
           set -e
           cat example.txt
           grep -q '1+2=3' example.txt
+  test-windows:
+    name: Compile example document with Windows
+    strategy:
+      fail-fast: true
+      matrix:
+        command:
+          - context                        --luatex              --nonstopmode  example.context
+          - pdflatex --shell-escape                  --interaction=nonstopmode  example.latex
+          - xelatex  --shell-escape --8bit           --interaction=nonstopmode  example.latex
+          - lualatex                                 --interaction=nonstopmode  example.latex
+          - pdftex   --shell-escape                  --interaction=nonstopmode  example.plaintex
+          - xetex    --shell-escape --8bit           --interaction=nonstopmode  example.plaintex
+          - luatex                                   --interaction=nonstopmode  example.plaintex
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install TeX Live
+        uses: teatimeguest/setup-texlive-action@v3
+        with:
+          packages: |
+            context
+            latex
+            luatex
+            scheme-minimal
+            standalone
+            xetex
+      - name: Install lt3luabridge
+        run: xetex lt3luabridge.ins
+      - name: Compile example document
+        run: ${{ matrix.command }}
   prerelease:
     name: Create artifacts and optionally prerelease the package
     needs:
       - markdownlint
-      - test
+      - test-linux
+      - test-windows
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           packages: |
             collection-latex
+            collection-luatex
             context
             latex
             luatex
@@ -85,6 +86,7 @@ jobs:
         with:
           packages: |
             collection-latex
+            collection-luatex
             context
             latex
             luatex

--- a/example.tex
+++ b/example.tex
@@ -1,0 +1,15 @@
+\input expl3-generic
+\ExplSyntaxOn
+\str_case:Vn
+  \c_sys_engine_format_str
+  {
+    { pdftex   } { \def \file { example.plaintex } }
+    { luatex   } { \def \file { example.plaintex } }
+    { xetex    } { \def \file { example.plaintex } }
+    { pdflatex } { \def \file { example.latex    } }
+    { lualatex } { \def \file { example.latex    } }
+    { xelatex  } { \def \file { example.latex    } }
+    { cont-en  } { \def \file { example.context  } }
+  }
+\ExplSyntaxOff
+\input\file\relax

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -408,8 +408,7 @@
                   }
                 \sys_if_platform_windows:T
                   {
-                    @echo~off \iow_newline:
-                    if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
+                    @ if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
                       set~TEXMF_OUTPUT_DIRECTORY = . ) \iow_newline:
                   }
               }

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -397,24 +397,37 @@
 % use the current working directory (\texttt{.}) instead.
 %
 %    \begin{macrocode}
-            \str_if_eq:NNT
+            \str_if_eq:NNTF
               \g_luabridge_output_dirname_str
               \c_luabridge_default_output_dirname_str
               {
-                \sys_if_platform_unix:T
+                \sys_if_platform_windows:TF
                   {
-                    TEXMF_OUTPUT_DIRECTORY =
-                      ${TEXMF_OUTPUT_DIRECTORY:-.} \iow_newline:
+                    if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
+                      texlua~
+                        \g_luabridge_helper_script_filename_str
+                    )~else~(
+                      texlua~
+                        \g_luabridge_output_dirname_str /
+                        \g_luabridge_helper_script_filename_str
+                    )
                   }
-                \sys_if_platform_windows:T
                   {
-                    @ if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
-                      set~TEXMF_OUTPUT_DIRECTORY = . ) \iow_newline:
+                    \sys_if_platform_unix:T
+                      {
+                        TEXMF_OUTPUT_DIRECTORY =
+                          ${TEXMF_OUTPUT_DIRECTORY:-.} \iow_newline:
+                      }
+                    texlua~
+                      \g_luabridge_output_dirname_str /
+                      \g_luabridge_helper_script_filename_str
                   }
               }
-            texlua~
-              \g_luabridge_output_dirname_str /
-              \g_luabridge_helper_script_filename_str
+              {
+                texlua~
+                  \g_luabridge_output_dirname_str /
+                  \g_luabridge_helper_script_filename_str
+              }
           }
           { }
           #1

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -281,7 +281,7 @@
             \str_set:Nn
               \l_tmpa_str
               { TEXMF_OUTPUT_DIRECTORY }
-            \str_put_right:NV
+            \str_put_left:NV
               \l_tmpa_str
               \c_percent_str
             \str_put_right:NV
@@ -403,12 +403,13 @@
               {
                 \sys_if_platform_unix:T
                   {
-                    TEXMF_OUTPUT_DIRECTORY = ${TEXMF_OUTPUT_DIRECTORY:-.} ;
+                    TEXMF_OUTPUT_DIRECTORY =
+                      ${TEXMF_OUTPUT_DIRECTORY:-.} ;
                   }
                 \sys_if_platform_windows:T
                   {
-                    if~not~defined~TEXMF_OUTPUT_DIRECTORY
-                      ( set~TEXMF_OUTPUT_DIRECTORY = . ) ;
+                    if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
+                      set~TEXMF_OUTPUT_DIRECTORY = . ) &&
                   }
               }
             texlua~

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -406,15 +406,8 @@
                     TEXMF_OUTPUT_DIRECTORY =
                       ${TEXMF_OUTPUT_DIRECTORY:-.} \iow_newline:
                   }
-                \sys_if_platform_windows:T
-                  {
-                    @echo~off \iow_newline:
-                    if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
-                      set~TEXMF_OUTPUT_DIRECTORY = . ) \iow_newline:
-                  }
               }
             texlua~
-              \g_luabridge_output_dirname_str /
               \g_luabridge_helper_script_filename_str
           }
           { }

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -406,8 +406,15 @@
                     TEXMF_OUTPUT_DIRECTORY =
                       ${TEXMF_OUTPUT_DIRECTORY:-.} \iow_newline:
                   }
+                \sys_if_platform_windows:T
+                  {
+                    @echo~off \iow_newline:
+                    if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
+                      set~TEXMF_OUTPUT_DIRECTORY = . ) \iow_newline:
+                  }
               }
             texlua~
+              \g_luabridge_output_dirname_str /
               \g_luabridge_helper_script_filename_str
           }
           { }

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -404,12 +404,13 @@
                 \sys_if_platform_unix:T
                   {
                     TEXMF_OUTPUT_DIRECTORY =
-                      ${TEXMF_OUTPUT_DIRECTORY:-.} ;
+                      ${TEXMF_OUTPUT_DIRECTORY:-.} \iow_newline:
                   }
                 \sys_if_platform_windows:T
                   {
+                    @echo~off \iow_newline:
                     if~not~defined~TEXMF_OUTPUT_DIRECTORY~(
-                      set~TEXMF_OUTPUT_DIRECTORY = . ) &&
+                      set~TEXMF_OUTPUT_DIRECTORY = . ) \iow_newline:
                   }
               }
             texlua~

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -151,7 +151,7 @@
 %   \texttt{-output-directory} parameter of the \TeX{} engine.
 % \end{variable}
 %
-% \begin{variable}[added = 2022-06-26]{\c_luabridge_default_output_dirname_str}
+% \begin{variable}[added = 2022-06-26, updated = 2024-07-03]{\c_luabridge_default_output_dirname_str}
 %   This constant is the default value of \cs{g_luabridge_output_dirname_str}.
 % \end{variable}
 %
@@ -261,9 +261,42 @@
   =
   { \c_luabridge_method_shell_int }
   {
-    \str_const:Nn
-      \c_luabridge_default_output_dirname_str
-      { . }
+%    \end{macrocode}
+%
+% Instead of assuming the current working directory as the output directory,
+% try to determine the output directory from the environmental variable
+% \texttt{TEXMF_OUTPUT_DIRECTORY}, which is automatically defined by \TeX{}
+% engines and accessible from child processes.
+%
+%    \begin{macrocode}
+    \sys_if_platform_unix:TF
+      {
+        \str_const:Nn
+          \c_luabridge_default_output_dirname_str
+          { $TEXMF_OUTPUT_DIRECTORY }
+      }
+      {
+        \sys_if_platform_windows:TF
+          {
+            \str_set:Nn
+              \l_tmpa_str
+              { TEXMF_OUTPUT_DIRECTORY }
+            \str_put_right:NV
+              \l_tmpa_str
+              \c_percent_str
+            \str_put_right:NV
+              \l_tmpa_str
+              \c_percent_str
+            \str_const:NV
+              \c_luabridge_default_output_dirname_str
+              \l_tmpa_str
+          }
+          {
+            \str_const:Nn
+              \c_luabridge_default_output_dirname_str
+              { . }
+          }
+      }
     \str_const:Nx
       \c_luabridge_default_helper_script_filename_str
       { \jobname.luabridge.lua }
@@ -358,6 +391,26 @@
           \g_luabridge_helper_script_filename_str
         \sys_get_shell:xnNTF
           {
+%    \end{macrocode}
+%
+% If the environmental variable \texttt{TEXMF_OUTPUT_DIRECTORY} is undefined,
+% use the current working directory (\texttt{.}) instead.
+%
+%    \begin{macrocode}
+            \str_if_eq:NNT
+              \g_luabridge_output_dirname_str
+              \c_luabridge_default_output_dirname_str
+              {
+                \sys_if_platform_unix:T
+                  {
+                    TEXMF_OUTPUT_DIRECTORY = ${TEXMF_OUTPUT_DIRECTORY:-.} ;
+                  }
+                \sys_if_platform_windows:T
+                  {
+                    if~not~defined~TEXMF_OUTPUT_DIRECTORY
+                      ( set~TEXMF_OUTPUT_DIRECTORY = . ) ;
+                  }
+              }
             texlua~
               \g_luabridge_output_dirname_str /
               \g_luabridge_helper_script_filename_str


### PR DESCRIPTION
### Tasks

- [x] Automatically determine value of `\c_luabridge_default_output_dirname_str` based on `-output-directory` on Linux.
- [x] Automatically determine value of `\c_luabridge_default_output_dirname_str` based on `-output-directory` on Windows.
- [x] Test setting / not setting `-output-directory .` in the CI.

Closes #26.