### PR TITLE
Use explcheck to check expl3 code in the continuous integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
           ln -s . lt3luabridge
           zip -@ lt3luabridge < RELEASE_FILES
       - name: Upload artifact lt3luabridge.zip
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: lt3luabridge.zip
           path: lt3luabridge.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Run MarkdownLint
         uses: nosborn/github-action-markdown-cli@v2.0.0
   explcheck:
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install TeX Live
         uses: teatimeguest/setup-texlive-action@v3
         with:
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           set -e
@@ -112,7 +112,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install TeX Live
         uses: teatimeguest/setup-texlive-action@v3
         with:
@@ -143,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Install dependencies
         run: |
           set -e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,7 @@ jobs:
             expltools
             scheme-minimal
             xetex
+          cache: false
       - name: Install lt3luabridge
         run: xetex lt3luabridge.ins
       - name: Run explcheck

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install lt3luabridge
         run: xetex lt3luabridge.ins
       - name: Run explcheck
-        run: explcheck *.tex *.sty
+        run: explcheck --warnings-are-errors -- lt3luabridge.tex
   test-linux:
     name: Compile example document with Linux
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,23 @@ jobs:
         uses: actions/checkout@v2
       - name: Run MarkdownLint
         uses: nosborn/github-action-markdown-cli@v2.0.0
+  explcheck:
+    name: Run explcheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install TeX Live
+        uses: teatimeguest/setup-texlive-action@v3
+        with:
+          packages: |
+            expltools
+            scheme-minimal
+            xetex
+      - name: Install lt3luabridge
+        run: xetex lt3luabridge.ins
+      - name: Run explcheck
+        run: explcheck *.tex *.sty
   test-linux:
     name: Compile example document with Linux
     strategy:
@@ -120,6 +137,7 @@ jobs:
     name: Create artifacts and optionally prerelease the package
     needs:
       - markdownlint
+      - explcheck
       - test-linux
       - test-windows
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
             expltools
             scheme-minimal
             xetex
-          cache: false
       - name: Install lt3luabridge
         run: xetex lt3luabridge.ins
       - name: Run explcheck

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,8 @@
 
 Continuous Integration:
 
-- Use explcheck to validate the expl3 code.
+- Use explcheck to check expl3 code in the continuous integration.
+  (witiko/markdown#535, #30)
 
 ## 2.2.0 (2024-07-03)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 2.2.1
+
+Continuous Integration:
+
+- Use explcheck to validate the expl3 code.
+
 ## 2.2.0 (2024-07-03)
 
 Development:

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -186,7 +186,7 @@
 %    \begin{macrocode}
 %<@@=luabridge>
 %<*generic-package>
-\ifx\ExplSyntaxOn\undefined
+\ifx\csname ExplSyntaxOn\endcsname\undefined
   \input expl3-generic\relax
 \fi
 \ExplSyntaxOn

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -186,7 +186,7 @@
 %    \begin{macrocode}
 %<@@=luabridge>
 %<*generic-package>
-\ifx\csname ExplSyntaxOn\endcsname\undefined
+\expandafter\ifx\csname ExplSyntaxOn\endcsname\relax
   \input expl3-generic\relax
 \fi
 \ExplSyntaxOn


### PR DESCRIPTION
This PR adds explcheck to the CI, as discussed in https://github.com/Witiko/markdown/issues/535.