### PR TITLE
Prevent unintended expansion of `\input` and similar commands in `\luabridge_tl_set:Nn` in LuaTeX

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## 2.2.1
 
+Fixes:
+
+- Prevent unintended expansion of `\input` and similar commands in
+  `\luabridge_tl_set:Nn` in LuaTeX. (witiko/markdown#530, #29)
+
 Continuous Integration:
 
 - Use explcheck to check expl3 code in the continuous integration.

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -47,7 +47,7 @@
 %    }^^A
 % }
 %
-% \date{Released 2024-07-03}
+% \date{Released 2024-12-16}
 %
 % \maketitle
 %
@@ -562,7 +562,7 @@
 \RequirePackage{expl3}
 \ProvidesExplPackage
   {lt3luabridge}%
-  {2024-07-03}%
+  {2024-12-16}%
   {2.2.0}%
   {An expl3 package that allows you to execute Lua code in LuaTeX or any other
    TeX engine that exposes the shell}

--- a/lt3luabridge.dtx
+++ b/lt3luabridge.dtx
@@ -516,11 +516,14 @@
             end~
             \exp_not:V \l_tmpa_tl
           }
-        \tl_set:Nf
+        \tl_set:No
           #1
           {
-            \lua_now:V
-              \l_tmpa_tl
+            \directlua
+              {
+                \tl_use:N
+                  \l_tmpa_tl
+              }
           }
       }
     \cs_generate_variant:Nn


### PR DESCRIPTION
Closes #29.